### PR TITLE
Remove TestRetort

### DIFF
--- a/src/adaptix/_internal/morphing/load_error.py
+++ b/src/adaptix/_internal/morphing/load_error.py
@@ -1,9 +1,9 @@
 import dataclasses
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Iterable, Optional, Sequence, Union
+from typing import Any, Iterable, Optional, Union
 
-from ..common import TypeHint
+from ..common import TypeHint, VarTuple
 from ..compat import CompatExceptionGroup
 from ..utils import fix_dataclass_from_builtin, with_module
 
@@ -47,10 +47,10 @@ class LoadExceptionGroup(CompatExceptionGroup[LoadError], LoadError):
     """The base class integrating ``ExceptionGroup`` into the ``LoadError`` hierarchy"""
 
     message: str
-    exceptions: Sequence[LoadError]
+    exceptions: VarTuple[LoadError]
 
     # stub `__init__` is required for right introspection
-    def __init__(self, message: str, exceptions: Sequence[LoadError]):
+    def __init__(self, message: str, exceptions: VarTuple[LoadError]):
         pass
 
 

--- a/src/adaptix/_internal/morphing/load_error.py
+++ b/src/adaptix/_internal/morphing/load_error.py
@@ -1,9 +1,9 @@
 import dataclasses
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Iterable, Optional, Sequence, Union
 
-from ..common import TypeHint, VarTuple
+from ..common import TypeHint
 from ..compat import CompatExceptionGroup
 from ..utils import fix_dataclass_from_builtin, with_module
 
@@ -47,10 +47,10 @@ class LoadExceptionGroup(CompatExceptionGroup[LoadError], LoadError):
     """The base class integrating ``ExceptionGroup`` into the ``LoadError`` hierarchy"""
 
     message: str
-    exceptions: VarTuple[LoadError]
+    exceptions: Sequence[LoadError]
 
     # stub `__init__` is required for right introspection
-    def __init__(self, message: str, exceptions: VarTuple[LoadError]):
+    def __init__(self, message: str, exceptions: Sequence[LoadError]):
         pass
 
 

--- a/tests/tests_helpers/tests_helpers/__init__.py
+++ b/tests/tests_helpers/tests_helpers/__init__.py
@@ -4,7 +4,6 @@ from .misc import (
     DebugCtx,
     FailedRequirement,
     PlaceholderProvider,
-    TestRetort,
     cond_list,
     create_sa_engine,
     full_match,

--- a/tests/tests_helpers/tests_helpers/misc.py
+++ b/tests/tests_helpers/tests_helpers/misc.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import Engine, create_engine
 
-from adaptix import AdornedRetort, CannotProvide, DebugTrail, Mediator, NoSuitableProvider, Provider, Request
+from adaptix import CannotProvide, DebugTrail, Mediator, NoSuitableProvider, Provider, Request
 from adaptix._internal.compat import CompatExceptionGroup
 from adaptix._internal.feature_requirement import DistributionVersionRequirement, Requirement
 from adaptix._internal.morphing.model.basic_gen import CodeGenAccumulator
@@ -35,11 +35,6 @@ def requires(requirement: Requirement):
         )(func)
 
     return wrapper
-
-
-class TestRetort(AdornedRetort):
-    def provide(self, request: Request[T]) -> T:
-        return self._facade_provide(request, error_message=f"cannot provide {request}")
 
 
 E = TypeVar("E", bound=Exception)

--- a/tests/unit/morphing/generic_provider/test_literal_provider.py
+++ b/tests/unit/morphing/generic_provider/test_literal_provider.py
@@ -3,19 +3,14 @@ from enum import Enum
 from typing import Literal
 from uuid import uuid4
 
-import pytest
 from tests_helpers import raises_exc
 
 from adaptix import Retort
 from adaptix._internal.morphing.load_error import BadVariantLoadError
 
 
-@pytest.fixture()
-def retort():
-    return Retort()
-
-
-def test_loader_base(retort, strict_coercion, debug_trail):
+def test_loader_base(strict_coercion, debug_trail):
+    retort = Retort()
     loader = retort.replace(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
@@ -41,12 +36,14 @@ def _is_exact_one(arg):
     return type(arg) is int and arg == 1  # noqa: E721
 
 
-def test_strict_coercion(retort, debug_trail):
+def test_strict_coercion(debug_trail):
     # Literal definition could have very strange behavior
     # due to type cache and 0 == False, 1 == True,
     # so Literal[0, 1] sometimes returns Literal[False, True]
     # and vice versa.
     # We add a random string at the end to suppress caching
+
+    retort = Retort()
     rnd_val1 = uuid4().hex
     literal_loader = retort.replace(
         strict_coercion=True,
@@ -88,7 +85,9 @@ def test_strict_coercion(retort, debug_trail):
     )
 
 
-def test_loader_with_enums(retort, strict_coercion, debug_trail):
+def test_loader_with_enums(strict_coercion, debug_trail):
+    retort = Retort()
+
     class Enum1(Enum):
         CASE1 = 1
         CASE2 = 2
@@ -125,7 +124,9 @@ def test_loader_with_enums(retort, strict_coercion, debug_trail):
     )
 
 
-def test_dumper_with_enums(retort, strict_coercion, debug_trail):
+def test_dumper_with_enums(strict_coercion, debug_trail):
+    retort = Retort()
+
     class Enum1(Enum):
         CASE1 = 1
         CASE2 = 2

--- a/tests/unit/morphing/generic_provider/test_literal_provider.py
+++ b/tests/unit/morphing/generic_provider/test_literal_provider.py
@@ -4,22 +4,15 @@ from typing import Literal
 from uuid import uuid4
 
 import pytest
-from tests_helpers import TestRetort, raises_exc
+from tests_helpers import raises_exc
 
-from adaptix._internal.morphing.enum_provider import EnumExactValueProvider
-from adaptix._internal.morphing.generic_provider import LiteralProvider, UnionProvider
+from adaptix import Retort
 from adaptix._internal.morphing.load_error import BadVariantLoadError
 
 
 @pytest.fixture()
 def retort():
-    return TestRetort(
-        recipe=[
-            LiteralProvider(),
-            EnumExactValueProvider(),
-            UnionProvider(),
-        ],
-    )
+    return Retort()
 
 
 def test_loader_base(retort, strict_coercion, debug_trail):

--- a/tests/unit/morphing/generic_provider/test_union_provider.py
+++ b/tests/unit/morphing/generic_provider/test_union_provider.py
@@ -16,12 +16,8 @@ class Book:
     author: Union[str, List[str]]
 
 
-@pytest.fixture()
-def retort():
-    return Retort()
-
-
-def test_loading(retort, strict_coercion, debug_trail):
+def test_loading(strict_coercion, debug_trail):
+    retort = Retort()
     loader_ = retort.replace(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
@@ -65,7 +61,8 @@ def bad_int_loader(data):
     raise TypeError  # must raise LoadError instance (TypeLoadError)
 
 
-def test_loading_unexpected_error(retort, strict_coercion, debug_trail):
+def test_loading_unexpected_error(strict_coercion, debug_trail):
+    retort = Retort()
     loader_ = retort.replace(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
@@ -96,7 +93,8 @@ def test_loading_unexpected_error(retort, strict_coercion, debug_trail):
         )
 
 
-def test_dumping(retort, debug_trail):
+def test_dumping(debug_trail):
+    retort = Retort()
     dumper_ = retort.replace(
         debug_trail=debug_trail,
     ).get_dumper(
@@ -107,7 +105,8 @@ def test_dumping(retort, debug_trail):
     assert dumper_("a") == "a"
 
 
-def test_dumping_of_none(retort, debug_trail):
+def test_dumping_of_none(debug_trail):
+    retort = Retort()
     dumper_ = retort.replace(
         debug_trail=debug_trail,
     ).get_dumper(
@@ -119,7 +118,7 @@ def test_dumping_of_none(retort, debug_trail):
     assert dumper_(None) is None
 
 
-def test_dumping_subclass(retort, debug_trail):
+def test_dumping_subclass(debug_trail):
     @dataclass
     class Parent:
         foo: int
@@ -144,7 +143,8 @@ def test_dumping_subclass(retort, debug_trail):
     )
 
 
-def test_optional_dumping(retort, debug_trail):
+def test_optional_dumping(debug_trail):
+    retort = Retort()
     opt_dumper = retort.replace(
         debug_trail=debug_trail,
     ).get_dumper(
@@ -155,7 +155,8 @@ def test_optional_dumping(retort, debug_trail):
     assert opt_dumper(None) is None
 
 
-def test_bad_optional_dumping(retort, debug_trail):
+def test_bad_optional_dumping(debug_trail):
+    retort = Retort()
     raises_exc(
         with_cause(
             NoSuitableProvider(

--- a/tests/unit/morphing/generic_provider/test_union_provider.py
+++ b/tests/unit/morphing/generic_provider/test_union_provider.py
@@ -3,11 +3,10 @@ from decimal import Decimal
 from typing import Callable, List, Literal, Optional, Union
 
 import pytest
-from tests_helpers import TestRetort, raises_exc, with_cause, with_notes
+from tests_helpers import raises_exc, with_cause, with_notes
 
 from adaptix import CannotProvide, DebugTrail, NoSuitableProvider, Retort, dumper, loader
 from adaptix._internal.compat import CompatExceptionGroup
-from adaptix._internal.morphing.generic_provider import LiteralProvider, UnionProvider
 from adaptix._internal.morphing.load_error import BadVariantLoadError, LoadError, TypeLoadError, UnionLoadError
 
 
@@ -37,9 +36,8 @@ def make_dumper(tp: type):
 
 @pytest.fixture()
 def retort():
-    return TestRetort(
+    return Retort(
         recipe=[
-            UnionProvider(),
             make_loader(str),
             make_loader(int),
             make_dumper(str),
@@ -221,14 +219,7 @@ def test_bad_optional_dumping(retort, debug_trail):
 
 
 def test_literal(strict_coercion, debug_trail):
-    retort = TestRetort(
-        recipe=[
-            LiteralProvider(),
-            UnionProvider(),
-            make_loader(type(None)),
-            make_dumper(type(None)),
-        ],
-    )
+    retort = Retort()
 
     loader_ = retort.replace(
         strict_coercion=strict_coercion,

--- a/tests/unit/morphing/model/test_dumper_provider.py
+++ b/tests/unit/morphing/model/test_dumper_provider.py
@@ -5,9 +5,9 @@ from typing import Any, Callable, Dict, Optional, Type
 from unittest.mock import ANY
 
 import pytest
-from tests_helpers import DebugCtx, TestRetort, full_match, parametrize_bool, raises_exc, with_trail
+from tests_helpers import DebugCtx, full_match, parametrize_bool, raises_exc, with_trail
 
-from adaptix import DebugTrail, Dumper, bound
+from adaptix import DebugTrail, Dumper, Retort, bound
 from adaptix._internal.common import Catchable
 from adaptix._internal.compat import CompatExceptionGroup
 from adaptix._internal.model_tools.definitions import (
@@ -92,7 +92,7 @@ def make_dumper_getter(
     debug_ctx: DebugCtx,
 ) -> Callable[[], Dumper]:
     def getter():
-        retort = TestRetort(
+        retort = Retort(
             recipe=[
                 ValueProvider(OutputShapeRequest, shape),
                 ValueProvider(OutputNameLayoutRequest, name_layout),

--- a/tests/unit/morphing/model/test_loader_provider.py
+++ b/tests/unit/morphing/model/test_loader_provider.py
@@ -33,7 +33,6 @@ from adaptix._internal.morphing.model.crown_definitions import (
     InputNameLayout,
     InputNameLayoutRequest,
 )
-from adaptix._internal.morphing.model.loader_provider import ModelLoaderProvider
 from adaptix._internal.morphing.request_cls import LoaderRequest
 from adaptix._internal.provider.provider_template import ValueProvider
 from adaptix._internal.provider.shape_provider import InputShapeRequest

--- a/tests/unit/morphing/model/test_loader_provider.py
+++ b/tests/unit/morphing/model/test_loader_provider.py
@@ -5,9 +5,9 @@ from types import MappingProxyType
 from typing import Any, Callable, Dict, Optional
 
 import pytest
-from tests_helpers import DebugCtx, TestRetort, full_match, parametrize_bool, raises_exc, with_trail
+from tests_helpers import DebugCtx, full_match, parametrize_bool, raises_exc, with_trail
 
-from adaptix import DebugTrail, ExtraKwargs, Loader, bound
+from adaptix import DebugTrail, ExtraKwargs, Loader, Retort, bound
 from adaptix._internal.common import VarTuple
 from adaptix._internal.model_tools.definitions import (
     Default,
@@ -115,13 +115,11 @@ def make_loader_getter(
     debug_ctx: DebugCtx,
 ) -> Callable[[], Loader]:
     def getter():
-        retort = TestRetort(
+        retort = Retort(
             recipe=[
                 ValueProvider(InputShapeRequest, shape),
                 ValueProvider(InputNameLayoutRequest, name_layout),
                 bound(int, ValueProvider(LoaderRequest, int_loader)),
-                ModelLoaderProvider(),
-                debug_ctx.accum,
             ],
         )
         return retort.replace(

--- a/tests/unit/morphing/name_layout/test_provider.py
+++ b/tests/unit/morphing/name_layout/test_provider.py
@@ -14,7 +14,6 @@ from adaptix import (
     NoSuitableProvider,
     Provider,
     Retort,
-    bound,
     name_mapping,
 )
 from adaptix._internal.model_tools.definitions import (
@@ -54,14 +53,6 @@ from adaptix._internal.morphing.model.crown_definitions import (
     OutputNameLayout,
     OutputNameLayoutRequest,
 )
-from adaptix._internal.morphing.model.dumper_provider import ModelDumperProvider
-from adaptix._internal.morphing.model.loader_provider import ModelLoaderProvider
-from adaptix._internal.morphing.name_layout.component import (
-    BuiltinExtraMoveAndPoliciesMaker,
-    BuiltinSievesMaker,
-    BuiltinStructureMaker,
-)
-from adaptix._internal.morphing.name_layout.provider import BuiltinNameLayoutProvider
 from adaptix._internal.morphing.request_cls import DumperRequest, LoaderRequest
 from adaptix._internal.provider.loc_stack_filtering import P
 from adaptix._internal.provider.provider_template import ValueProvider
@@ -162,14 +153,14 @@ def make_layouts(
     )
 
     cannot_provide_text = "cannot provide {}"
-    inp_name_layout = retort._facade_provide(inp_request, error_message=cannot_provide_text.format(inp_request))  # noqa
-    out_name_layout = retort._facade_provide(out_request, error_message=cannot_provide_text.format(out_request))  # noqa
+    inp_name_layout = retort._facade_provide(inp_request, error_message=cannot_provide_text.format(inp_request))
+    out_name_layout = retort._facade_provide(out_request, error_message=cannot_provide_text.format(out_request))
 
     loader_request = LoaderRequest(loc_stack=LocStack(loc))
-    retort._facade_provide(loader_request, error_message=cannot_provide_text.format(loader_request))  # noqa
+    retort._facade_provide(loader_request, error_message=cannot_provide_text.format(loader_request))
 
     dumper_request = DumperRequest(loc_stack=LocStack(loc))
-    retort._facade_provide(dumper_request, error_message=cannot_provide_text.format(dumper_request))  # noqa
+    retort._facade_provide(dumper_request, error_message=cannot_provide_text.format(dumper_request))
     return Layouts(inp_name_layout, out_name_layout)
 
 

--- a/tests/unit/morphing/test_constant_length_tuple_provider.py
+++ b/tests/unit/morphing/test_constant_length_tuple_provider.py
@@ -4,9 +4,9 @@ import typing
 from typing import Mapping, Tuple
 
 import pytest
-from tests_helpers import TestRetort, raises_exc, requires, with_trail
+from tests_helpers import raises_exc, requires, with_trail
 
-from adaptix import DebugTrail, NoSuitableProvider, dumper, loader
+from adaptix import AdornedRetort, DebugTrail, NoSuitableProvider, dumper, loader
 from adaptix._internal.compat import CompatExceptionGroup
 from adaptix._internal.feature_requirement import HAS_UNPACK
 from adaptix._internal.morphing.concrete_provider import INT_LOADER_PROVIDER, STR_LOADER_PROVIDER
@@ -29,7 +29,7 @@ def int_dumper(data):
 
 @pytest.fixture()
 def retort():
-    return TestRetort(
+    return AdornedRetort(
         recipe=[
             ConstantLengthTupleProvider(),
             STR_LOADER_PROVIDER,

--- a/tests/unit/morphing/test_dict_provider.py
+++ b/tests/unit/morphing/test_dict_provider.py
@@ -3,13 +3,10 @@ from collections import defaultdict
 from typing import DefaultDict, Dict, List
 
 import pytest
-from tests_helpers import TestRetort, raises_exc, with_trail
+from tests_helpers import raises_exc, with_trail
 
-from adaptix import DebugTrail, default_dict, dumper, loader
+from adaptix import DebugTrail, Retort, default_dict, dumper, loader
 from adaptix._internal.compat import CompatExceptionGroup
-from adaptix._internal.morphing.concrete_provider import STR_LOADER_PROVIDER
-from adaptix._internal.morphing.dict_provider import DefaultDictProvider, DictProvider
-from adaptix._internal.morphing.iterable_provider import IterableProvider
 from adaptix._internal.morphing.load_error import AggregateLoadError
 from adaptix._internal.struct_trail import ItemKey
 from adaptix.load_error import TypeLoadError
@@ -23,13 +20,9 @@ def string_dumper(data):
 
 @pytest.fixture()
 def retort():
-    return TestRetort(
+    return Retort(
         recipe=[
-            DictProvider(),
-            DefaultDictProvider(),
-            STR_LOADER_PROVIDER,
             dumper(str, string_dumper),
-            IterableProvider(),
         ],
     )
 
@@ -161,16 +154,7 @@ def test_dumping(retort, debug_trail):
 
     assert dumper_({"a": "b", "c": "d"}) == {"a": "b", "c": "d"}
 
-    if debug_trail == DebugTrail.DISABLE:
-        raises_exc(
-            TypeError(),
-            lambda: dumper_({"a": "b", "c": 0}),
-        )
-        raises_exc(
-            TypeError(),
-            lambda: dumper_({"a": "b", 0: "d"}),
-        )
-    elif debug_trail == DebugTrail.FIRST:
+    if debug_trail == DebugTrail.FIRST:
         raises_exc(
             with_trail(TypeError(), ["c"]),
             lambda: dumper_({"a": "b", "c": 0}),

--- a/tests/unit/morphing/test_enum_provider.py
+++ b/tests/unit/morphing/test_enum_provider.py
@@ -13,7 +13,6 @@ from adaptix import (
     enum_by_name,
     enum_by_value,
     flag_by_member_names,
-    loader,
 )
 from adaptix._internal.morphing.enum_provider import EnumExactValueProvider
 from adaptix._internal.morphing.load_error import (

--- a/tests/unit/morphing/test_enum_provider.py
+++ b/tests/unit/morphing/test_enum_provider.py
@@ -2,7 +2,7 @@ from enum import Enum, Flag, IntEnum, auto
 from typing import Iterable, Mapping, Union
 
 import pytest
-from tests_helpers import TestRetort, parametrize_bool, raises_exc, with_cause, with_notes
+from tests_helpers import parametrize_bool, raises_exc, with_cause, with_notes
 
 from adaptix import (
     CannotProvide,
@@ -115,12 +115,9 @@ def test_name_provider_with_mapping(strict_coercion, debug_trail, mapping_option
 
 @pytest.mark.parametrize("enum_cls", [MyEnum, MyEnumWithMissingHook])
 def test_exact_value_provider(strict_coercion, debug_trail, enum_cls):
-    retort = TestRetort(
+    retort = Retort(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
-        recipe=[
-            EnumExactValueProvider(),
-        ],
     )
 
     loader = retort.get_loader(enum_cls)
@@ -148,12 +145,9 @@ def test_exact_value_provider(strict_coercion, debug_trail, enum_cls):
 
 
 def test_exact_value_provider_int_enum(strict_coercion, debug_trail):
-    retort = TestRetort(
+    retort = Retort(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
-        recipe=[
-            EnumExactValueProvider(),
-        ],
     )
     int_enum_loader = retort.get_loader(MyIntEnum)
 
@@ -180,12 +174,11 @@ def custom_string_dumper(value: str):
 
 
 def test_value_provider(strict_coercion, debug_trail):
-    retort = TestRetort(
+    retort = Retort(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
         recipe=[
             enum_by_value(MyEnum, tp=str),
-            loader(str, str),
             dumper(str, custom_string_dumper),
         ],
     )
@@ -193,16 +186,18 @@ def test_value_provider(strict_coercion, debug_trail):
     enum_loader = retort.get_loader(MyEnum)
 
     assert enum_loader("1") == MyEnum.V1
-    assert enum_loader(1) == MyEnum.V1
+
+    if not strict_coercion:
+        assert enum_loader(1) == MyEnum.V1
+
+        raises_exc(
+            MsgLoadError("Bad enum value", MyEnum.V1),
+            lambda: enum_loader(MyEnum.V1),
+        )
 
     raises_exc(
         MsgLoadError("Bad enum value", "V1"),
         lambda: enum_loader("V1"),
-    )
-
-    raises_exc(
-        MsgLoadError("Bad enum value", MyEnum.V1),
-        lambda: enum_loader(MyEnum.V1),
     )
 
     enum_dumper = retort.get_dumper(MyEnum)

--- a/tests/unit/morphing/test_iterable_provider.py
+++ b/tests/unit/morphing/test_iterable_provider.py
@@ -44,7 +44,7 @@ def retort():
 
 
 @pytest.mark.parametrize("mapping_type", [dict, Dict, Mapping, collections.Counter])
-def test_mapping_providing(retort, strict_coercion, debug_trail, mapping_type):
+def test_mapping_providing(strict_coercion, debug_trail, mapping_type):
     retort = AdornedRetort(
         recipe=[
             IterableProvider(),

--- a/tests/unit/morphing/test_iterable_provider.py
+++ b/tests/unit/morphing/test_iterable_provider.py
@@ -21,9 +21,8 @@ from typing import (
 import pytest
 from tests_helpers import raises_exc, with_trail
 
-from adaptix import AdornedRetort, DebugTrail, NoSuitableProvider, dumper, loader
+from adaptix import AdornedRetort, DebugTrail, NoSuitableProvider, Retort, dumper, loader
 from adaptix._internal.compat import CompatExceptionGroup
-from adaptix._internal.morphing.concrete_provider import STR_LOADER_PROVIDER
 from adaptix._internal.morphing.iterable_provider import IterableProvider
 from adaptix._internal.morphing.load_error import AggregateLoadError
 from adaptix.load_error import ExcludedTypeLoadError, TypeLoadError
@@ -37,26 +36,20 @@ def string_dumper(data):
 
 @pytest.fixture()
 def retort():
-    return AdornedRetort(
+    return Retort(
         recipe=[
-            IterableProvider(),
-            STR_LOADER_PROVIDER,
             dumper(str, string_dumper),
         ],
     )
 
 
-@pytest.mark.parametrize(
-    "mapping_type",
-    [
-        (dict,),
-        (Dict,),
-        (Mapping,),
-        (collections.Counter,),
-    ],
-)
+@pytest.mark.parametrize("mapping_type", [dict, Dict, Mapping, collections.Counter])
 def test_mapping_providing(retort, strict_coercion, debug_trail, mapping_type):
-    retort = retort.replace(
+    retort = AdornedRetort(
+        recipe=[
+            IterableProvider(),
+        ],
+    ).replace(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
     )

--- a/tests/unit/morphing/test_iterable_provider.py
+++ b/tests/unit/morphing/test_iterable_provider.py
@@ -19,9 +19,9 @@ from typing import (
 )
 
 import pytest
-from tests_helpers import TestRetort, raises_exc, with_trail
+from tests_helpers import raises_exc, with_trail
 
-from adaptix import DebugTrail, NoSuitableProvider, dumper, loader
+from adaptix import AdornedRetort, DebugTrail, NoSuitableProvider, dumper, loader
 from adaptix._internal.compat import CompatExceptionGroup
 from adaptix._internal.morphing.concrete_provider import STR_LOADER_PROVIDER
 from adaptix._internal.morphing.iterable_provider import IterableProvider
@@ -37,7 +37,7 @@ def string_dumper(data):
 
 @pytest.fixture()
 def retort():
-    return TestRetort(
+    return AdornedRetort(
         recipe=[
             IterableProvider(),
             STR_LOADER_PROVIDER,
@@ -46,23 +46,23 @@ def retort():
     )
 
 
-def test_mapping_providing(retort, strict_coercion, debug_trail):
+@pytest.mark.parametrize(
+    ["mapping_type"],
+    [
+        (dict,),
+        (Dict,),
+        (Mapping,),
+        (collections.Counter,),
+    ],
+)
+def test_mapping_providing(retort, strict_coercion, debug_trail, mapping_type):
     retort = retort.replace(
         strict_coercion=strict_coercion,
         debug_trail=debug_trail,
     )
 
     with pytest.raises(NoSuitableProvider):
-        retort.get_loader(dict)
-
-    with pytest.raises(NoSuitableProvider):
-        retort.get_loader(Dict)
-
-    with pytest.raises(NoSuitableProvider):
-        retort.get_loader(Mapping)
-
-    with pytest.raises(NoSuitableProvider):
-        retort.get_loader(collections.Counter)
+        retort.get_loader(mapping_type)
 
 
 def test_loading(retort, strict_coercion, debug_trail):

--- a/tests/unit/morphing/test_iterable_provider.py
+++ b/tests/unit/morphing/test_iterable_provider.py
@@ -47,7 +47,7 @@ def retort():
 
 
 @pytest.mark.parametrize(
-    ["mapping_type"],
+    "mapping_type",
     [
         (dict,),
         (Dict,),

--- a/tests/unit/provider/test_overlay_schema.py
+++ b/tests/unit/provider/test_overlay_schema.py
@@ -49,7 +49,7 @@ def provide_overlay_schema(recipe: Iterable[Provider], provide_action: Callable[
     )
 
     request = SampleRequest()
-    return retort._facade_provide(request, error_message=f"cannot provide {request}")  # noqa
+    return retort._facade_provide(request, error_message=f"cannot provide {request}")
 
 
 class MyClass1:

--- a/tests/unit/provider/test_overlay_schema.py
+++ b/tests/unit/provider/test_overlay_schema.py
@@ -2,9 +2,9 @@ from dataclasses import dataclass
 from typing import Callable, Iterable
 
 import pytest
-from tests_helpers import TestRetort, full_match
+from tests_helpers import full_match
 
-from adaptix import Chain, Mediator, Omittable, Omitted, Provider, Request, bound
+from adaptix import AdornedRetort, Chain, Mediator, Omittable, Omitted, Provider, Request, bound
 from adaptix._internal.common import VarTuple
 from adaptix._internal.provider.overlay_schema import Overlay, OverlayProvider, Schema, provide_schema
 from adaptix._internal.provider.request_cls import LocStack, TypeHintLoc
@@ -41,13 +41,15 @@ class SampleRequestProvider(StaticProvider):
 
 
 def provide_overlay_schema(recipe: Iterable[Provider], provide_action: Callable[[Mediator], MySchema]) -> MySchema:
-    retort = TestRetort(
+    retort = AdornedRetort(
         recipe=[
             *recipe,
             SampleRequestProvider(provide_action),
         ],
     )
-    return retort.provide(SampleRequest())
+
+    request = SampleRequest()
+    return retort._facade_provide(request, error_message=f"cannot provide {request}")  # noqa
 
 
 class MyClass1:


### PR DESCRIPTION
Removing TestRetort for lack of need, and because it may not obviously work and may cause errors. (suggested by @zhPavel)