### PR TITLE
Remove ``strip_annotated`` function

### DIFF
--- a/src/adaptix/_internal/type_tools/norm_utils.py
+++ b/src/adaptix/_internal/type_tools/norm_utils.py
@@ -26,12 +26,6 @@ def strip_tags(norm: BaseNormType) -> BaseNormType:
 N = TypeVar("N", bound=BaseNormType)
 
 
-def strip_annotated(value: N) -> N:
-    if HAS_ANNOTATED and isinstance(value, BaseNormType) and value.origin == typing.Annotated:
-        return strip_annotated(value)
-    return value
-
-
 def is_class_var(norm: BaseNormType) -> bool:
     if norm.origin == ClassVar:
         return True


### PR DESCRIPTION
The goal of ``strip_annotated`` was conversion from ``Annotated[1, metadata]`` to `1`.
[The specification of Python typehints](https://typing.readthedocs.io/en/latest/spec/qualifiers.html#annotated) says that ``Annotated`` should be parameterized with a type, ``Annotated[1, metadata]`` is not a valid typehint.
Additionally, ``strip_annotated`` can lead to infinite recursion under certain circumstances, making it broken by design.