### PR TITLE
Normalize non-ASCII errors in Base64 bytes loaders

### DIFF
--- a/docs/changelog/fragments/+strict_base64.bugfix.rst
+++ b/docs/changelog/fragments/+strict_base64.bugfix.rst
@@ -1,0 +1,1 @@
+Reject leading and excess padding when loading Base64-encoded bytes-like values.

--- a/docs/changelog/fragments/+strict_base64.bugfix.rst
+++ b/docs/changelog/fragments/+strict_base64.bugfix.rst
@@ -1,1 +1,1 @@
-Reject leading and excess padding when loading Base64-encoded bytes-like values.
+Report non-ASCII Base64 input as a loader error for bytes-like values.

--- a/src/adaptix/_internal/morphing/concrete_provider.py
+++ b/src/adaptix/_internal/morphing/concrete_provider.py
@@ -275,6 +275,7 @@ class _Base64JSONSchemaMixin(JSONSchemaProvider):
 
 
 B64_PATTERN = re.compile(b"[A-Za-z0-9+/]*={0,2}")
+BAD_BASE64_STRING = "Bad base64 string"
 
 
 @for_predicate(bytes)
@@ -289,17 +290,17 @@ class BytesBase64Provider(_Base64DumperMixin, _Base64JSONSchemaMixin, MorphingPr
             except AttributeError:
                 raise TypeLoadError(str, data)
             except UnicodeEncodeError:
-                raise ValueLoadError("Bad base64 string", data)
+                raise ValueLoadError(BAD_BASE64_STRING, data)
 
             if not B64_PATTERN.fullmatch(encoded):
-                raise ValueLoadError("Bad base64 string", data)
+                raise ValueLoadError(BAD_BASE64_STRING, data)
             if b"=" in encoded:
                 # a2b_base64 accepts leading and excess padding, so reject padding
                 # beyond the amount implied by the unpadded data length first.
                 unpadded = encoded.rstrip(b"=")
                 padding_length = len(encoded) - len(unpadded)
                 if not unpadded or padding_length > -len(unpadded) % 4:
-                    raise ValueLoadError("Bad base64 string", data)
+                    raise ValueLoadError(BAD_BASE64_STRING, data)
 
             try:
                 return a2b_base64(encoded)

--- a/src/adaptix/_internal/morphing/concrete_provider.py
+++ b/src/adaptix/_internal/morphing/concrete_provider.py
@@ -275,7 +275,6 @@ class _Base64JSONSchemaMixin(JSONSchemaProvider):
 
 
 B64_PATTERN = re.compile(b"[A-Za-z0-9+/]*={0,2}")
-BAD_BASE64_STRING = "Bad base64 string"
 
 
 @for_predicate(bytes)
@@ -290,17 +289,10 @@ class BytesBase64Provider(_Base64DumperMixin, _Base64JSONSchemaMixin, MorphingPr
             except AttributeError:
                 raise TypeLoadError(str, data)
             except UnicodeEncodeError:
-                raise ValueLoadError(BAD_BASE64_STRING, data)
+                raise ValueLoadError("Bad base64 string", data)
 
             if not B64_PATTERN.fullmatch(encoded):
-                raise ValueLoadError(BAD_BASE64_STRING, data)
-            if b"=" in encoded:
-                # a2b_base64 accepts leading and excess padding, so reject padding
-                # beyond the amount implied by the unpadded data length first.
-                unpadded = encoded.rstrip(b"=")
-                padding_length = len(encoded) - len(unpadded)
-                if not unpadded or padding_length > -len(unpadded) % 4:
-                    raise ValueLoadError(BAD_BASE64_STRING, data)
+                raise ValueLoadError("Bad base64 string", data)
 
             try:
                 return a2b_base64(encoded)

--- a/src/adaptix/_internal/morphing/concrete_provider.py
+++ b/src/adaptix/_internal/morphing/concrete_provider.py
@@ -288,9 +288,18 @@ class BytesBase64Provider(_Base64DumperMixin, _Base64JSONSchemaMixin, MorphingPr
                 encoded = data.encode("ascii")
             except AttributeError:
                 raise TypeLoadError(str, data)
+            except UnicodeEncodeError:
+                raise ValueLoadError("Bad base64 string", data)
 
             if not B64_PATTERN.fullmatch(encoded):
                 raise ValueLoadError("Bad base64 string", data)
+            if b"=" in encoded:
+                # a2b_base64 accepts leading and excess padding, so reject padding
+                # beyond the amount implied by the unpadded data length first.
+                unpadded = encoded.rstrip(b"=")
+                padding_length = len(encoded) - len(unpadded)
+                if not unpadded or padding_length > -len(unpadded) % 4:
+                    raise ValueLoadError("Bad base64 string", data)
 
             try:
                 return a2b_base64(encoded)

--- a/tests/unit/morphing/test_concrete_provider.py
+++ b/tests/unit/morphing/test_concrete_provider.py
@@ -353,9 +353,6 @@ def test_bytes_like_provider(
     b64_string = b"YWJjZA=="
 
     assert get_string(loader(b64_string.decode())) == string
-    assert get_string(loader("")) == ""
-    assert get_string(loader("YQ==")) == "a"
-    assert get_string(loader("YWI=")) == "ab"
 
     raises_exc(
         ValueLoadError("Bad base64 string", "Hello, world"),
@@ -379,18 +376,6 @@ def test_bytes_like_provider(
         ValueLoadError("Incorrect padding", "YWJjZA"),
         lambda: loader("YWJjZA"),
     )
-
-    for invalid_base64 in (
-        "=",
-        "==",
-        "AAA==",
-        "AAAA=",
-        "AAAA==",
-    ):
-        raises_exc(
-            ValueLoadError("Bad base64 string", invalid_base64),
-            lambda invalid_base64=invalid_base64: loader(invalid_base64),
-        )
 
     raises_exc(
         TypeLoadError(str, 108),

--- a/tests/unit/morphing/test_concrete_provider.py
+++ b/tests/unit/morphing/test_concrete_provider.py
@@ -353,10 +353,18 @@ def test_bytes_like_provider(
     b64_string = b"YWJjZA=="
 
     assert get_string(loader(b64_string.decode())) == string
+    assert get_string(loader("")) == ""
+    assert get_string(loader("YQ==")) == "a"
+    assert get_string(loader("YWI=")) == "ab"
 
     raises_exc(
         ValueLoadError("Bad base64 string", "Hello, world"),
         lambda: loader("Hello, world"),
+    )
+
+    raises_exc(
+        ValueLoadError("Bad base64 string", "🦄"),
+        lambda: loader("🦄"),
     )
 
     raises_exc(
@@ -371,6 +379,18 @@ def test_bytes_like_provider(
         ValueLoadError("Incorrect padding", "YWJjZA"),
         lambda: loader("YWJjZA"),
     )
+
+    for invalid_base64 in (
+        "=",
+        "==",
+        "AAA==",
+        "AAAA=",
+        "AAAA==",
+    ):
+        raises_exc(
+            ValueLoadError("Bad base64 string", invalid_base64),
+            lambda invalid_base64=invalid_base64: loader(invalid_base64),
+        )
 
     raises_exc(
         TypeLoadError(str, 108),


### PR DESCRIPTION
## Problem

The bytes-like Base64 loaders encode string input as ASCII before decoding. Non-ASCII input therefore leaks `UnicodeEncodeError` instead of using the provider's `ValueLoadError` contract.

## Fix

Convert `UnicodeEncodeError` to `ValueLoadError("Bad base64 string", data)` in the shared bytes loader. This covers `bytes`, `bytearray`, `BytesIO`, and `IO[bytes]` loaders. Padding behavior is unchanged.

## Validation

- Python 3.11 concrete-provider tests: 306 passed
- Targeted public-seam matrix: 24 passed across result type, coercion, and debug-trail combinations
- Mutation check: removing the Unicode handler makes all 24 targeted cases fail
- Ruff 0.14.14 and `git diff --check`: passed